### PR TITLE
feat: Allow RegExg flags to be configured through module options 

### DIFF
--- a/lib/module.js
+++ b/lib/module.js
@@ -1,6 +1,7 @@
 async function redirectModule(moduleOptions) {
   const defaults = {
     rules: [],
+    flags: '',
     onDecode: (req, res, next) => decodeURI(req.url),
     onDecodeError: (error, req, res, next) => next(error)
   }
@@ -10,8 +11,8 @@ async function redirectModule(moduleOptions) {
     ...await parseOptions(this.options.redirect),
     ...await parseOptions(moduleOptions)
   }
-
-  options.rules = options.rules.map(rule => ({ ...rule, from: new RegExp(rule.from) }))
+console.log('redirect options', options);
+  options.rules = options.rules.map(rule => ({ ...rule, from: new RegExp(rule.from, options.flags) }))
 
   const middleware = require('./middleware.js')(options)
   this.addServerMiddleware(middleware)

--- a/lib/module.js
+++ b/lib/module.js
@@ -11,7 +11,6 @@ async function redirectModule(moduleOptions) {
     ...await parseOptions(this.options.redirect),
     ...await parseOptions(moduleOptions)
   }
-console.log('redirect options', options);
   options.rules = options.rules.map(rule => ({ ...rule, from: new RegExp(rule.from, options.flags) }))
 
   const middleware = require('./middleware.js')(options)


### PR DESCRIPTION
Request title says it all.

```
export default {
  modules: [
    // Module using defaults
    '@nuxtjs/redirect-module'

    // Module using passed in RegEx flags
    ['@nuxtjs/redirect-module', { flags: 'i' }]
  ]
}