### PR TITLE
feat: adds option to set default statusCode

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,12 @@ You can set decode.
 
 You can set callback when there is an error in the decode.
 
+### `statusCode`
+
+- Default: `302`
+
+You can set the default statusCode which gets used when no statusCode is defined on the rule itself.
+
 ## Usage
 
 Simply add the links you want to redirect as objects to the module option array:
@@ -120,7 +126,7 @@ redirect: async () => {
 }
 ```
 
-Now, if you want to customize your redirects, how your decode is done 
+Now, if you want to customize your redirects, how your decode is done
 or when there is some error in the decode, you can also:
 
 ```js

--- a/lib/middleware.js
+++ b/lib/middleware.js
@@ -23,7 +23,7 @@ module.exports = function (options) {
     const toTarget = typeof foundRule.to === 'function' ? await foundRule.to(foundRule.from, req) : foundRule.to
     const toUrl = decodedBaseUrl.replace(foundRule.from, toTarget)
 
-    res.statusCode = foundRule.statusCode || 302
+    res.statusCode = foundRule.statusCode || options.statusCode
     res.setHeader('Location', toUrl)
     res.end()
   }

--- a/lib/module.js
+++ b/lib/module.js
@@ -2,7 +2,8 @@ async function redirectModule(moduleOptions) {
   const defaults = {
     rules: [],
     onDecode: (req, res, next) => decodeURI(req.url),
-    onDecodeError: (error, req, res, next) => next(error)
+    onDecodeError: (error, req, res, next) => next(error),
+    statusCode: 302
   }
 
   const options = {

--- a/test/module.test.js
+++ b/test/module.test.js
@@ -119,6 +119,34 @@ describe('function inline', () => {
   testSuite()
 })
 
+describe('default statusCode', () => {
+  beforeAll(async () => {
+    nuxt = await setupNuxt({
+      ...config,
+      redirect: {
+        rules: redirects,
+        statusCode: 301
+      }
+    })
+  })
+
+  afterAll(async () => {
+    await nuxt.close()
+  })
+
+  test('301 Moved Permanently', async () => {
+    try {
+      await request({
+        uri: url('/redirected'),
+        resolveWithFullResponse: true,
+        followRedirect: false
+      })
+    } catch (e) {
+      expect(e.statusCode).toBe(301)
+    }
+  })
+})
+
 describe('error', () => {
   const e = new Error('Error on decode')
 


### PR DESCRIPTION
Adds statusCode field in options to set default for all rules:

`
		[
			'@nuxtjs/redirect-module',
			{
				rules: [],
				statusCode: 301
			}
		]`

