### PR TITLE
fix: handling some unhandled error cases

### DIFF
--- a/lib/middleware.js
+++ b/lib/middleware.js
@@ -20,11 +20,25 @@ module.exports = function (options) {
     // 2) string
     // 3) function taking from & req (when from is regex, req might be more interesting)
 
-    const toTarget = typeof foundRule.to === 'function' ? await foundRule.to(foundRule.from, req) : foundRule.to
+    let toTarget
+
+    try {
+      toTarget = typeof foundRule.to === 'function' ? await foundRule.to(foundRule.from, req) : foundRule.to
+    } catch (error) {
+      return next(error)
+    }
+
     const toUrl = decodedBaseUrl.replace(foundRule.from, toTarget)
 
+    try {
+      res.setHeader('Location', toUrl)
+    } catch (error) {
+      // Not passing the error as it's caused by URL that was user-provided so we
+      // can't do anything about the error.
+      return next()
+    }
+
     res.statusCode = foundRule.statusCode || options.statusCode
-    res.setHeader('Location', toUrl)
     res.end()
   }
 }

--- a/test/fixture/redirects.js
+++ b/test/fixture/redirects.js
@@ -16,5 +16,9 @@ module.exports = [
       const param = req.url.match(/functionAsync\/(.*)$/)[1]
       setTimeout(() => resolve(`/posts/${param}`), 2000)
     })
+  },
+  {
+    from: '^/errorInToFunction$',
+    to: () => Promise.reject(new Error('forced error'))
   }
 ]

--- a/test/module.test.js
+++ b/test/module.test.js
@@ -42,6 +42,24 @@ const testSuite = () => {
     expect(html).toContain('Works!')
   })
 
+  test('redirect error with control character', async () => {
+    const requestOptions = {
+      uri: url(encodeURI('/mapped/ab\u0001')),
+      resolveWithFullResponse: true
+    }
+
+    await expect(request(requestOptions)).rejects.toHaveProperty('statusCode', 404)
+  })
+
+  test('redirect error with failing "to" function', async () => {
+    const requestOptions = {
+      uri: url('/errorInToFunction'),
+      resolveWithFullResponse: true
+    }
+
+    await expect(request(requestOptions)).rejects.toHaveProperty('statusCode', 500)
+  })
+
   test('many redirect', async () => {
     for (const n of ['abcde', 'abcdeasd', 'raeasdsads']) {
       const html = await get(`/many/${n}`)


### PR DESCRIPTION
 - Handle error in res.setHeader API. Errors can happen here depdending
   on provided input URL and we can't handle it any any reasonable way
   so pass URL to next handler.
 - Handle potential error when calling 'to' function. This function is
   controlled by us (through settings) so propagate error to the app.