### PR TITLE
fix: crash on init with inline-style options

### DIFF
--- a/lib/module.js
+++ b/lib/module.js
@@ -18,7 +18,7 @@ async function redirectModule (moduleOptions) {
   this.addServerMiddleware(middleware)
 }
 
-async function parseOptions (options) {
+async function parseOptions (options = {}) {
   if (typeof options === 'function') {
     options = await options()
   }

--- a/test/module.test.js
+++ b/test/module.test.js
@@ -121,13 +121,17 @@ describe('function', () => {
 })
 
 describe('function inline', () => {
+  const inlineConfig = {
+    ...config,
+    modules: [
+      [require('../'), redirects]
+    ]
+  }
+
+  delete inlineConfig.redirect
+
   beforeAll(async () => {
-    nuxt = await setupNuxt({
-      ...config,
-      modules: [
-        [require('../'), redirects]
-      ]
-    })
+    nuxt = await setupNuxt(inlineConfig)
   })
 
   afterAll(async () => {


### PR DESCRIPTION
Module just crashed on parsing options when non-inline
(this.options.redirect) options were not provided. While there was a
test already that tested inline options, it didn't remove non-inline
options from config object so it didn't fail.