### PR TITLE
fix: encode URIs before setting them as `Location` header

### DIFF
--- a/lib/middleware.js
+++ b/lib/middleware.js
@@ -1,6 +1,6 @@
 // Creates new middleware using provided options
 module.exports = function (options) {
-  return async function redirectRoute(req, res, next) {
+  return async function redirectRoute (req, res, next) {
     let decodedBaseUrl
 
     try {

--- a/lib/middleware.js
+++ b/lib/middleware.js
@@ -1,6 +1,6 @@
 // Creates new middleware using provided options
 module.exports = function (options) {
-  return async function redirectRoute (req, res, next) {
+  return async function redirectRoute(req, res, next) {
     let decodedBaseUrl
 
     try {
@@ -31,7 +31,7 @@ module.exports = function (options) {
     const toUrl = decodedBaseUrl.replace(foundRule.from, toTarget)
 
     try {
-      res.setHeader('Location', toUrl)
+      res.setHeader('Location', encodeURI(toUrl))
     } catch (error) {
       // Not passing the error as it's caused by URL that was user-provided so we
       // can't do anything about the error.

--- a/lib/module.js
+++ b/lib/module.js
@@ -1,4 +1,4 @@
-async function redirectModule(moduleOptions) {
+async function redirectModule (moduleOptions) {
   const defaults = {
     rules: [],
     onDecode: (req, res, next) => decodeURI(req.url),
@@ -18,7 +18,7 @@ async function redirectModule(moduleOptions) {
   this.addServerMiddleware(middleware)
 }
 
-async function parseOptions(options = {}) {
+async function parseOptions (options = {}) {
   if (typeof options === 'function') {
     options = await options()
   }

--- a/lib/module.js
+++ b/lib/module.js
@@ -1,4 +1,4 @@
-async function redirectModule (moduleOptions) {
+async function redirectModule(moduleOptions) {
   const defaults = {
     rules: [],
     onDecode: (req, res, next) => decodeURI(req.url),
@@ -18,7 +18,7 @@ async function redirectModule (moduleOptions) {
   this.addServerMiddleware(middleware)
 }
 
-async function parseOptions (options = {}) {
+async function parseOptions(options = {}) {
   if (typeof options === 'function') {
     options = await options()
   }

--- a/test/fixture/redirects.js
+++ b/test/fixture/redirects.js
@@ -1,6 +1,7 @@
 module.exports = [
   { from: '^/redirected', to: '/' },
   { from: /^\/äßU</, to: '/' },
+  { from: '^/äöü$', to: '/äßU<' },
   { from: '^/many/(.*)$', to: '/posts/abcde' },
   { from: '^/mapped/(.*)$', to: '/posts/$1' },
   { from: '^/function$', to: () => '/' },

--- a/test/fixture/redirects.js
+++ b/test/fixture/redirects.js
@@ -18,6 +18,7 @@ module.exports = [
       setTimeout(() => resolve(`/posts/${param}`), 2000)
     })
   },
+  { from: '^/errorInTo$', to: '/mapped/\uD800ab\u0001/' },
   {
     from: '^/errorInToFunction$',
     to: () => Promise.reject(new Error('forced error'))

--- a/test/module.test.js
+++ b/test/module.test.js
@@ -42,6 +42,11 @@ const testSuite = () => {
     expect(html).toContain('Works!')
   })
 
+  test('non-ascii redirect to another non-ascii url', async () => {
+    const html = await get('/äöü')
+    expect(html).toContain('Works!')
+  })
+
   test('redirect error with control character', async () => {
     const requestOptions = {
       uri: url(encodeURI('/mapped/ab\u0001')),

--- a/test/module.test.js
+++ b/test/module.test.js
@@ -48,7 +48,7 @@ const testSuite = () => {
   })
 
   test('redirect with control character', async () => {
-    const html = await get(encodeURI('/mapped/ab\u0001'));
+    const html = await get(encodeURI('/mapped/ab\u0001'))
     expect(html).toContain('ab')
   })
 

--- a/test/module.test.js
+++ b/test/module.test.js
@@ -47,9 +47,14 @@ const testSuite = () => {
     expect(html).toContain('Works!')
   })
 
-  test('redirect error with control character', async () => {
+  test('redirect with control character', async () => {
+    const html = await get(encodeURI('/mapped/ab\u0001'));
+    expect(html).toContain('ab')
+  })
+
+  test('redirect error due to malformatted target url', async () => {
     const requestOptions = {
-      uri: url(encodeURI('/mapped/ab\u0001')),
+      uri: url('/errorInTo'),
       resolveWithFullResponse: true
     }
 


### PR DESCRIPTION
As per RFC 2616 specified, the Location header should be a clean ASCII URI (therefore special characters should be encoded). This should fix #56  aswell.

I've refactored the test cases aswell: the existing one ("redirect error with control character") shouldn't throw an error imo (as it is a valid url - please correct me if I'm wrong) + I've added a test covering an invalid target url instead.