### PR TITLE
fix: don't forward error from decodeURI to next middleware

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ You can set decode.
 
 ### `onDecodeError`
 
-- Default: `(error, req, res, next) => next(error)`
+- Default: `(error, req, res, next) => next()`
 
 You can set callback when there is an error in the decode.
 

--- a/lib/module.js
+++ b/lib/module.js
@@ -2,7 +2,7 @@ async function redirectModule (moduleOptions) {
   const defaults = {
     rules: [],
     onDecode: (req, res, next) => decodeURI(req.url),
-    onDecodeError: (error, req, res, next) => next(error),
+    onDecodeError: (_error, _req, _res, next) => next(),
     statusCode: 302
   }
 

--- a/test/module.test.js
+++ b/test/module.test.js
@@ -52,6 +52,12 @@ const testSuite = () => {
     expect(html).toContain('ab')
   })
 
+  test('redirect with malformed URI', async () => {
+    await expect(get('/%83')).rejects.toMatchObject({
+      statusCode: 400
+    })
+  })
+
   test('redirect error due to malformatted target url', async () => {
     const requestOptions = {
       uri: url('/errorInTo'),
@@ -195,6 +201,9 @@ describe('error', () => {
           if (req.url === '/error') {
             throw e
           }
+        },
+        onDecodeError: (error, _req, _res, next) => {
+          next(error)
         }
       }
     })


### PR DESCRIPTION
Instead of forwarding error from `decodeURI` further to the
error middleware and subsequently triggering 500 response, just ignore it.

Ignoring the error will likely crash in Nuxt later anyway but that
is better as:
 - This package won't get the blame when error shows up locally or in production
 - Error triggered within Nuxt doesn't trigger 500 but 400 response
   which is better as this is input error rather than server error.